### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,8 @@ jobs:
     needs: tag-next-version
     if: ${{ needs.tag-next-version.outputs.hasNextVersion == 'true' }}
     runs-on: ubuntu-latest    
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3


### PR DESCRIPTION
Potential fix for [https://github.com/aimotrens/cruddy/security/code-scanning/13](https://github.com/aimotrens/cruddy/security/code-scanning/13)

To fix the issue, we need to add a `permissions` block to the `build-docker` job in the workflow file. The permissions should be set to the least privilege required for the job to function correctly. Since the job does not interact with repository contents, we can set `contents: read` as the minimal permission.

Steps to implement the fix:
1. Locate the `build-docker` job in the `.github/workflows/release.yml` file.
2. Add a `permissions` block under the job definition.
3. Set the permissions to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
